### PR TITLE
Add AllWork to Beekeeping TypeDef

### DIFF
--- a/1.1/Defs/WorkTypeDefs/WorkTypes.xml
+++ b/1.1/Defs/WorkTypeDefs/WorkTypes.xml
@@ -16,6 +16,7 @@
     <workTags>
       <li>ManualDumb</li>
       <li>Hauling</li>
+      <li>AllWork</li>
     </workTags>
   </WorkTypeDef>
 


### PR DESCRIPTION
AllWork is the tag that's used by Royalty's "lazy guests" who will not do any work to determine if it's a valid worktype that they should refuse to do.  Since beekeeping doesn't have this tag, visiting Janissaries and other such guests who will refuse to do any work will still do beekeeping work.  They treat it the same way as they do stuff like Bedrest.