### PR TITLE
Make Building_Beehouse public

### DIFF
--- a/1.3/Source/RimBees/RimBees/Buildings/Building_Beehouse.cs
+++ b/1.3/Source/RimBees/RimBees/Buildings/Building_Beehouse.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 
 namespace RimBees
 {
-    class Building_Beehouse : Building, IThingHolder
+    public class Building_Beehouse : Building, IThingHolder
     {
        
         public int tickCounter = 0;


### PR DESCRIPTION
Minor change to make `Building_Beehouse` a public class instead of an internal one. I'm using a local copy of the dll for my mod, so there's no urgency on merging this. For reference, I'm using the public properties `innerContainerDrones` and `innerContainerQueens`. If you want to change those or make those private, just give me a heads up and I'll swap to whatever you want me to use instead