### PR TITLE
Make psychotropic and black honey act like drugs

### DIFF
--- a/1.3/Defs/ThingDefs_Items/Items_Honey.xml
+++ b/1.3/Defs/ThingDefs_Items/Items_Honey.xml
@@ -74,7 +74,7 @@
 	<ThingDef ParentName="RB_HoneyBase">
 		<defName>RB_TastyHoney</defName>
 		<label>tasty honey</label>
-		<description>This honey has been extracted from honeycombs of the Nutritious family (Nutritious, Agricultural, Bittersweet, Egglaying and Lactic), and has a high nutritional value. However, it will decay very fast. Honey can be consumed raw or cooked with other ingredients.</description>  
+		<description>This honey has been extracted from honeycombs of the Nutritious family (Nutritious, Agricultural, Bittersweet, Egglaying and Lactic), and has a high nutritional value. However, it will decay very fast. Honey can be consumed raw or cooked with other ingredients.</description>
 		<graphicData>
 			<color>(184,59,56)</color>
 			<shaderType>CutoutComplex</shaderType>
@@ -97,7 +97,7 @@
 	<ThingDef ParentName="RB_HoneyBase">
 		<defName>RB_WhiteHoney</defName>
 		<label>white honey</label>
-		<description>This honey has been extracted from Hybrid honeycombs, and is very pale in colour. It is less nutritious than normal honey, but it is usually produced in high amounts. Honey can be consumed raw or cooked with other ingredients.</description>  
+		<description>This honey has been extracted from Hybrid honeycombs, and is very pale in colour. It is less nutritious than normal honey, but it is usually produced in high amounts. Honey can be consumed raw or cooked with other ingredients.</description>
 		<graphicData>
 			<shaderType>CutoutComplex</shaderType>
 		</graphicData>
@@ -116,7 +116,7 @@
 	<ThingDef ParentName="RB_HoneyBase">
 		<defName>RB_PsychotropicHoney</defName>
 		<label>psychotropic honey</label>
-		<description>This honey has been extracted from honeycombs of the Neutro family (Neutro, Tipsy, Luxurious, Psychic and Stoned) and bubbles constantly in a weird, mesmerizing dance. It is of little nutritional value, but produces a sense of euphoria when ingested. Honey can be consumed raw or cooked with other ingredients.</description>  
+		<description>This honey has been extracted from honeycombs of the Neutro family (Neutro, Tipsy, Luxurious, Psychic and Stoned) and bubbles constantly in a weird, mesmerizing dance. It is of little nutritional value, but produces a sense of euphoria when ingested. Honey can be consumed raw or cooked with other ingredients.</description>
 		<graphicData>
 			<color>(140,255,28)</color>
 			<shaderType>CutoutComplex</shaderType>
@@ -147,10 +147,10 @@
 	<ThingDef ParentName="RB_HoneyBase">
 		<defName>RB_AdaptiveHoney</defName>
 		<label>adaptive honey</label>
-		<description>This honey has been extracted from Adaptive honeycombs, and has a reddish brown colour and a pungent smell. This honey won't rot at all, so it can be stored indefinitely. Honey can be consumed raw or cooked with other ingredients.</description>		
+		<description>This honey has been extracted from Adaptive honeycombs, and has a reddish brown colour and a pungent smell. This honey won't rot at all, so it can be stored indefinitely. Honey can be consumed raw or cooked with other ingredients.</description>
 		<graphicData>
 			<color>(220,160,120)</color>
-			<shaderType>CutoutComplex</shaderType>			
+			<shaderType>CutoutComplex</shaderType>
 		</graphicData>
 		<statBases>
 			<MarketValue>1.9</MarketValue>
@@ -160,10 +160,10 @@
 	<ThingDef ParentName="RB_HoneyBase">
 		<defName>RB_BlackHoney</defName>
 		<label>black honey</label>
-		<description>This honey has been extracted from Nocturnal honeycombs, and is really dark and thick. It has certain health benefits, Improving blood filtration and pumping. Honey can be consumed raw or cooked with other ingredients.</description>
+		<description>This honey has been extracted from Nocturnal honeycombs, and is very dark and thick. It improves blood filtration and blood pumping when consumed. Honey can be consumed raw or cooked with other ingredients.</description>
 		<graphicData>
 			<color>(34,38,38)</color>
-			<shaderType>CutoutComplex</shaderType>	
+			<shaderType>CutoutComplex</shaderType>
 		</graphicData>
 		<statBases>
 			<MarketValue>1.9</MarketValue>

--- a/1.3/Defs/ThingDefs_Items/Items_Honey.xml
+++ b/1.3/Defs/ThingDefs_Items/Items_Honey.xml
@@ -128,11 +128,18 @@
 		<ingestible>
 			<tasteThought>RB_AtePsychotropicHoney</tasteThought>
 			<specialThoughtAsIngredient>RB_AtePsychotropicHoneyIngredient</specialThoughtAsIngredient>
+			<nurseable>true</nurseable>
+			<drugCategory>Social</drugCategory>
+			<joyKind>Chemical</joyKind>
+			<joy>0.2</joy>
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
 				<daysToRotStart>60</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
+			</li>
+			<li Class="CompProperties_Drug">
+				<listOrder>47</listOrder>
 			</li>
 		</comps>
 	</ThingDef>
@@ -168,11 +175,16 @@
 					<severity>1</severity>
 				</li>
 			</outcomeDoers>
+			<drugCategory>Medical</drugCategory>
+			<nurseable>true</nurseable>
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
 				<daysToRotStart>75</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
+			</li>
+			<li Class="CompProperties_Drug">
+				<listOrder>48</listOrder>
 			</li>
 		</comps>
 	</ThingDef>


### PR DESCRIPTION
This MR makes psychotropic and black honey act like drugs -- that is, they can be administered medically and taken on a schedule. Psychotropic honey also counts as a social drug and minor joy source.

**Balance changes**
- Psychotropic honey now gives 0.2 chemical joy because I needed some value to put in there to get it to work as a social drug. Maybe this is a good number?
- It's easier to boost incapacitated pawns' blood filtration and mood.

**Aesthetic changes**
- Adjusted the black honey description grammar
- Cleaned up stray spaces in the honey def XML

**Testing performed**

I've been running this for a couple of weeks without any issues. My focus has primarily been on the changes made. I am new to Rimworld modding, so there may be edge or corner cases I don't know about.

**Discussion**

Drug list orders chosen semi-arbitrarily,

I'm not sure whether this changes anything for teetotalers. AFAIK they don't object to psychotropic honey raw or in meals (should they?), so unless setting a chemical joyKind for it automatically sets up the aversion, behavior shouldn't have changed with this PR.

I'm open to suggestions, tweaks, releasing this as its own separate mod, whatever works with your vision for RimBees.